### PR TITLE
Playlist Helper Methods and Tests

### DIFF
--- a/SpotifyAPITestApp/SpotifyAPITestApp/PlaylistServiceTests/WhenThePlaylistServiceIsCalled_WithValidPlaylistName.cs
+++ b/SpotifyAPITestApp/SpotifyAPITestApp/PlaylistServiceTests/WhenThePlaylistServiceIsCalled_WithValidPlaylistName.cs
@@ -17,9 +17,47 @@ namespace SpotifyAPITestApp.PlaylistServiceTests
         }
 
         [Test]
-        public void i()
+        public void IDOfPlaylist_Is6QuKSXmuJpiHZec1mYrKwZ()
         {
-            Assert.That(_playlistService.PlaylistResponseDTO.Response.name, Is.EqualTo("New Playlist"));
+            Assert.That(_playlistService.GetPlaylistID(), Is.EqualTo("6QuKSXmuJpiHZec1mYrKwZ"));
+        }
+
+        [Test]
+        public void NameOfPlaylist_IsNewPlaylist()
+        {
+            // PlaylistResponseDTO.Response.name
+            Assert.That(_playlistService.GetPlaylistName(), Is.EqualTo("New Playlist"));
+        }
+
+        [Test]
+        public void TotalPlaylistFollowers_IsZero()
+        {
+            Assert.That(_playlistService.GetPlaylistTotalFollowers(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void PlaylistCollabartive_IsFalse()
+        {
+            Assert.That(_playlistService.CheckIfPlaylistIsCollaborative(), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void OwnerDisplayNameOfPlaylist_IsGuns_n_Spartans()
+        {
+            Assert.That(_playlistService.GetPlaylistOwnerDisplayName(), Is.EqualTo("Guns-n-Spartans"));
+        }
+
+        [Test]
+        public void PlaylistTotalTracks_IsZero()
+        {
+            Assert.That(_playlistService.GetPlaylistTotalTracks(), Is.EqualTo(0));
+        }
+
+        [Test]
+        [Ignore("Not Implemented")]
+        public void NameOfTrackInPlaylist_IsTrackNameHere()
+        {
+            //Assert.That(_playlistService.GetPlaylistName(), Is.EqualTo("New Playlist"));
         }
     }
 }

--- a/SpotifyAPITestApp/SpotifyAPITestApp/SinglePlaylistService.cs
+++ b/SpotifyAPITestApp/SpotifyAPITestApp/SinglePlaylistService.cs
@@ -61,5 +61,40 @@ namespace SpotifyAPITestApp
             PlaylistResponseDTO.DeserializeResponse(PlaylistResponse);
         }
 
+        // Test Help Methods:
+        public string GetPlaylistID()
+        {
+            return PlaylistResponseDTO.Response.id;
+        }
+
+        public string GetPlaylistName()
+        {
+            return PlaylistResponseDTO.Response.name;
+        }
+
+        public int GetPlaylistTotalFollowers()
+        {
+            return PlaylistResponseDTO.Response.followers.total;
+        }
+
+        public bool CheckIfPlaylistIsCollaborative()
+        {
+            return PlaylistResponseDTO.Response.collaborative;
+        }
+
+        public string GetPlaylistOwnerDisplayName()
+        {
+            return PlaylistResponseDTO.Response.owner.display_name;
+        }
+
+        public int GetPlaylistTotalTracks()
+        {
+            return PlaylistResponseDTO.Response.tracks.total;
+        }
+        // tracks.items.track.name string (possible loop)
+        public int GetPlaylistTrackName()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/SpotifyAPITestApp/SpotifyAPITestApp/SpotifyAPITestApp.csproj
+++ b/SpotifyAPITestApp/SpotifyAPITestApp/SpotifyAPITestApp.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <None Update="Testhost.dll.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Created Playlist helper methods and tests. The playlist ID test fails due to the actual result not matching the expected result.